### PR TITLE
Whitelist only what's necessary

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,5 +12,10 @@
   "homepage": "https://onxmaps.com",
   "peerDependencies": {
     "prettier": "3.x"
-  }
+  },
+  "files": [
+    "README.md",
+    "index.json",
+    "package.json"
+  ]
 }


### PR DESCRIPTION
All we really need in the package is `index.json`, but we'll leave the `package.json` and `README.md` in there too, no harm in that.